### PR TITLE
Add options for management user creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 sudo: required
 language: python
+python:
+  - "2.7"
 cache: pip
 services:
   - docker

--- a/tasks/config_management_user.yml
+++ b/tasks/config_management_user.yml
@@ -1,7 +1,12 @@
 ---
 - name: "Create management user by cli"
   shell: >
-    influx --execute "CREATE USER {{ influxdb_management_login_username }}
+    influx
+    {{ influxdb_management_hostname | ternary('-host ' + (influxdb_management_hostname | string),'') }}
+    {{ influxdb_management_port | ternary('-port ' + (influxdb_management_port | string), '' ) }}
+    {{ influxdb_management_ssl | ternary('-ssl ','') }}
+    {{ influxdb_management_validate_certs | ternary('', '-unsafeSsl ') }}
+    --execute "CREATE USER {{ influxdb_management_login_username }}
     WITH PASSWORD '{{ influxdb_management_login_password }}' WITH ALL PRIVILEGES"
     && touch /etc/influxdb/admin_user_created
   args:


### PR DESCRIPTION
Management user creation fail if the default port is changed or if the ssl is enabled

Add corresponding management options to the management user command creation if needed.
